### PR TITLE
Enable ACL on S3 Bucket creation

### DIFF
--- a/nextjs-lambda-cdk/lib/nextjs-lambda-cdk-stack.ts
+++ b/nextjs-lambda-cdk/lib/nextjs-lambda-cdk-stack.ts
@@ -69,6 +69,7 @@ export class NextjsLambdaCdkStack extends Stack {
       encryption: s3.BucketEncryption.S3_MANAGED,
       versioned: true,
       accessControl: s3.BucketAccessControl.LOG_DELIVERY_WRITE,
+      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER
     });
     
     const nextBucket = new s3.Bucket(this, 'next-bucket', {

--- a/nextjs-lambda-sam/template.yaml
+++ b/nextjs-lambda-sam/template.yaml
@@ -103,6 +103,9 @@ Resources:
       AccessControl: LogDeliveryWrite
       VersioningConfiguration:
         Status: Enabled
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
       BucketEncryption:
         ServerSideEncryptionConfiguration:
         - ServerSideEncryptionByDefault:


### PR DESCRIPTION
**Issue #, if available:**
Due to the new changes of S3 Bucket creation (April 2023), ACL's are disabled by default. Encountered error on the creation of S3 Bucket called NextLogging due to the value of accessControl value set as LogDeliveryState

**Description of changes:**
Set on both CDK and SAM templates "ObjectWriter" value to objectOwnership attribute so that ACL's can be enabled on the bucket in question. 
Explanation here: https://repost.aws/knowledge-center/cloudformation-objectownership-acl-error

**Testing**

1. How did you test these changes?
Deployed the next application using CDK and SAM templates
2. Can these changes be tested using one of the demo application? If yes, which demo application can be used to test it?
Yes used the provided next application

3. If applicable, have you run `npm run build` successfully locally to fix all warnings and errors?
Yes 

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
